### PR TITLE
A sizeable plugin update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: gradle
 
       # Set environment variables

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,13 +78,9 @@ jobs:
       - name: Run Tests
         run: ./gradlew test
 
-      # Run verifyPlugin Gradle task
+      # Run IntelliJ Plugin Verifier
       - name: Verify Plugin
-        run: ./gradlew verifyPlugin
-
-      # Run IntelliJ Plugin Verifier action using GitHub Action
-      - name: Run Plugin Verifier
-        run: ./gradlew runPluginVerifier -Pplugin.verifier.home.dir=${{ steps.properties.outputs.pluginVerifierHomeDir }}
+        run: ./gradlew verifyPlugin -Pplugin.verifier.home.dir=${{ steps.properties.outputs.pluginVerifierHomeDir }}
 
   # Build plugin with buildPlugin Gradle task and provide the artifact for the next workflow jobs
   # Requires test job to be passed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: gradle
 
       # Set environment variables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: gradle
 
       # Update Unreleased section with the current release note

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: gradle
 
       # Run IDEA prepared for UI testing

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 .qodana
 build
+.intellijPlatform

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,16 @@
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-fun properties(key: String) = project.findProperty(key).toString()
+fun properties(key: String) = project.findProperty(key)?.toString() ?: ""
 
 plugins {
     // Java support
     id("java")
     // Kotlin support
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "1.9.22"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.13.2"
+    id("org.jetbrains.intellij.platform") version "2.0.1"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "1.3.0"
 }
@@ -23,15 +24,36 @@ repositories {
 }
 
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-intellij {
-    pluginName.set(properties("pluginName"))
-    version.set(properties("platformVersion"))
-    type.set(properties("platformType"))
-    downloadSources.set(properties("platformDownloadSources").toBoolean())
-    updateSinceUntilBuild.set(false)
+intellijPlatform {
+    pluginConfiguration {
+        name = properties("pluginName")
+    }
 
-    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+    pluginVerification {
+        ides {
+            properties("pluginVerifierIdeVersions").split(',').map(String::trim).filter(String::isNotEmpty).forEach {
+                ide(IntelliJPlatformType.IntellijIdeaCommunity, it)
+            }
+            recommended()
+        }
+    }
+}
+
+repositories {
+    mavenCentral()
+    intellijPlatform.defaultRepositories()
+}
+
+dependencies {
+    intellijPlatform {
+        intellijIdeaCommunity(properties("platformVersion"))
+        plugins(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+        bundledPlugins(properties("platformBundledPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+
+        pluginVerifier()
+        instrumentationTools()
+        zipSigner()
+    }
 }
 
 tasks {
@@ -43,7 +65,7 @@ tasks {
         }
         withType<KotlinCompile> {
             kotlinOptions.jvmTarget = it
-            kotlinOptions.freeCompilerArgs += listOf("-Xjvm-default=enable")
+            kotlinOptions.freeCompilerArgs += listOf("-Xjvm-default=all-compatibility")
         }
     }
 
@@ -52,8 +74,8 @@ tasks {
     }
 
     patchPluginXml {
-        version.set(properties("pluginVersion"))
-        sinceBuild.set(properties("pluginSinceBuild"))
+        pluginVersion = properties("pluginVersion")
+        sinceBuild = properties("pluginSinceBuild")
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription.set(
@@ -76,17 +98,23 @@ tasks {
         })
     }
 
-    runPluginVerifier {
-        ideVersions.set(properties("pluginVerifierIdeVersions").split(',').map(String::trim).filter(String::isNotEmpty))
-    }
-
     // Configure UI tests plugin
     // Read more: https://github.com/JetBrains/intellij-ui-test-robot
-    runIdeForUiTests {
-        systemProperty("robot-server.port", "8082")
-        systemProperty("ide.mac.message.dialogs.as.sheets", "false")
-        systemProperty("jb.privacy.policy.text", "<!--999.999-->")
-        systemProperty("jb.consents.confirmation.enabled", "false")
+    val runIdeForUiTests by intellijPlatformTesting.runIde.registering {
+        task {
+            jvmArgumentProviders += CommandLineArgumentProvider {
+                listOf(
+                    "robot-server.port=8082",
+                    "ide.mac.message.dialogs.as.sheets=false",
+                    "jb.privacy.policy.text=<!--999.999-->",
+                    "jb.consents.confirmation.enabled=false",
+                )
+            }
+        }
+
+        plugins {
+            robotServerPlugin()
+        }
     }
 
     signPlugin {
@@ -101,7 +129,7 @@ tasks {
         // pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
+        channels.set(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').take(1))
     }
 
     buildSearchableOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,12 @@ repositories {
 intellijPlatform {
     pluginConfiguration {
         name = properties("pluginName")
+        version = properties("pluginVersion")
+
+        ideaVersion {
+            sinceBuild = properties("pluginSinceBuild")
+            untilBuild = provider { null } // Specify no latest build
+        }
     }
 
     pluginVerification {
@@ -74,9 +80,6 @@ tasks {
     }
 
     patchPluginXml {
-        pluginVersion = properties("pluginVersion")
-        sinceBuild = properties("pluginSinceBuild")
-
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription.set(
             projectDir.resolve("README.md").readText().lines().run {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,28 +3,26 @@
 
 pluginGroup = org.vineflower.ijplugin
 pluginName = Vineflower
-pluginVersion = 1.1
+pluginVersion = 1.1.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 231
+pluginSinceBuild = 241
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions = 2023.1.2
+pluginVerifierIdeVersions = 2024.1
 
-platformType = IC
-platformVersion = 2023.1.2
-platformDownloadSources = true
+platformVersion = 2024.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = com.intellij.java, org.jetbrains.kotlin, org.jetbrains.java.decompiler
+platformBundledPlugins = com.intellij.java, org.jetbrains.kotlin, org.jetbrains.java.decompiler
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 11
 
-gradleVersion = 7.2
+gradleVersion = 8.9
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,8 +19,8 @@ platformVersion = 2024.1
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformBundledPlugins = com.intellij.java, org.jetbrains.kotlin, org.jetbrains.java.decompiler
 
-# Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
-javaVersion = 11
+# Java language level used to compile sources and to generate the files for - Java 17 is required since 2022.2
+javaVersion = 17
 
 gradleVersion = 8.9
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/org/vineflower/ijplugin/VineflowerDecompilerBase.kt
+++ b/src/main/kotlin/org/vineflower/ijplugin/VineflowerDecompilerBase.kt
@@ -88,7 +88,7 @@ abstract class VineflowerDecompilerBase : ClassFileDecompilers.Full() {
         }
     }
 
-    override fun createFileViewProvider(file: VirtualFile, manager: PsiManager, physical: Boolean) =
+    override fun createFileViewProvider(file: VirtualFile, manager: PsiManager, physical: Boolean): FileViewProvider =
         MyFileViewProvider(manager, file, physical)
 
     abstract fun createDecompiledFile(viewProvider: FileViewProvider, contents: ResettableLazy<String>): PsiFile

--- a/src/main/kotlin/org/vineflower/ijplugin/VineflowerDecompilerKotlin.kt
+++ b/src/main/kotlin/org/vineflower/ijplugin/VineflowerDecompilerKotlin.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.stubs.KotlinFileStub
 import org.jetbrains.kotlin.psi.stubs.KotlinImportDirectiveStub
 
-// TODO: full decompilers
 class VineflowerDecompilerKotlin : VineflowerDecompilerBase() {
     private val myStubBuilder = StubBuilder()
 

--- a/src/main/kotlin/org/vineflower/ijplugin/VineflowerDecompilerKotlin.kt
+++ b/src/main/kotlin/org/vineflower/ijplugin/VineflowerDecompilerKotlin.kt
@@ -1,0 +1,76 @@
+package org.vineflower.ijplugin
+
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.FileViewProvider
+import com.intellij.psi.PsiManager
+import com.intellij.psi.compiled.ClsStubBuilder
+import com.intellij.psi.stubs.PsiFileStub
+import com.intellij.psi.stubs.PsiFileStubImpl
+import com.intellij.util.indexing.FileContent
+import org.jetbrains.kotlin.analysis.decompiler.psi.KotlinDecompiledFileViewProvider
+import org.jetbrains.kotlin.analysis.decompiler.psi.file.KtDecompiledFile
+import org.jetbrains.kotlin.analysis.decompiler.psi.text.DecompiledText
+import org.jetbrains.kotlin.idea.KotlinFileType
+import org.jetbrains.kotlin.idea.KotlinLanguage
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.stubs.KotlinFileStub
+import org.jetbrains.kotlin.psi.stubs.KotlinImportDirectiveStub
+
+// TODO: full decompilers
+class VineflowerDecompilerKotlin : VineflowerDecompilerBase() {
+    private val myStubBuilder = StubBuilder()
+
+    override val language = KotlinLanguage.INSTANCE
+    override val sourceFileType = KotlinFileType.INSTANCE
+
+    override fun acceptsLanguage(language: String) = language == "kotlin"
+
+    override fun getStubBuilder(): ClsStubBuilder = myStubBuilder
+
+    override fun createFileViewProvider(file: VirtualFile, manager: PsiManager, physical: Boolean) =
+        KotlinDecompiledFileViewProvider(manager, file, physical) {
+            MyDecompiledFile(it) { f ->
+                val text = getText(f)
+                DecompiledText(text)
+            }
+        }
+
+    override fun createDecompiledFile(viewProvider: FileViewProvider, contents: ResettableLazy<String>) =
+        error("Should not be called")
+
+    private inner class StubBuilder : ClsStubBuilder() {
+        private val logger = logger<StubBuilder>()
+
+        override fun getStubVersion() = -1
+
+        override fun buildFileStub(content: FileContent): PsiFileStub<*>? {
+            try {
+                val text = getText(content.file)
+                val viewProvider = KotlinDecompiledFileViewProvider(
+                    PsiManager.getInstance(content.project),
+                    content.file,
+                    true
+                ) { null }
+                val file = MyDecompiledFile(viewProvider) { DecompiledText(text) }
+                return DecompiledPsiStub(file)
+            } catch (e: ProcessCanceledException) {
+                throw e
+            } catch (e: Exception) {
+                logger.error("Failed to decompile ${content.file.url}", e)
+                return null
+            }
+        }
+    }
+
+    private class DecompiledPsiStub(file: KtDecompiledFile) : PsiFileStubImpl<KtFile>(file), KotlinFileStub {
+        override fun findImportsByAlias(alias: String) = emptyList<KotlinImportDirectiveStub>()
+        override fun getPackageFqName() = psi.packageFqName
+        override fun isScript() = false
+    }
+
+    private class MyDecompiledFile(viewProvider: KotlinDecompiledFileViewProvider, contents: (VirtualFile) -> DecompiledText) : KtDecompiledFile(viewProvider, contents) {
+        override fun getStub() = stubTree?.root as KotlinFileStub?
+    }
+}

--- a/src/main/kotlin/org/vineflower/ijplugin/VineflowerInvoker.kt
+++ b/src/main/kotlin/org/vineflower/ijplugin/VineflowerInvoker.kt
@@ -3,7 +3,6 @@ package org.vineflower.ijplugin
 import com.intellij.execution.filters.LineNumbersMapping
 import com.intellij.ide.highlighter.JavaClassFileType
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.DumbService
@@ -60,7 +59,7 @@ class VineflowerInvoker(classLoader: ClassLoader) {
         )
 
 
-    private val baseDecompilerClass = classLoader.loadClass("org.jetbrains.java.decompiler.main.decompiler.BaseDecompiler")
+    private val baseDecompilerClass = classLoader.loadClass("org.jetbrains.java.decompiler.main.Fernflower")
     private val baseDecompilerCtor = baseDecompilerClass.getConstructor(
         classLoader.loadClass("org.jetbrains.java.decompiler.main.extern.IBytecodeProvider"),
         classLoader.loadClass("org.jetbrains.java.decompiler.main.extern.IResultSaver"),
@@ -126,49 +125,48 @@ class VineflowerInvoker(classLoader: ClassLoader) {
         }
 
         // invoke the decompiler
-        if (ApplicationManager.getApplication().isWriteAccessAllowed) {
-            // Read actions from within the decompiler may create a deadlock, as the decompiler itself creates threads.
-            // Solve this problem by running the decompiler on a separate thread, and executing read actions on this
-            // thread, which has write access and therefore read access.
+        // Read actions from within the decompiler may create a deadlock, as the decompiler itself creates threads.
+        // Solve this problem by running the decompiler on a separate thread, and executing read actions on either
+        // this thread if given read access, or with a read action if not.
 
-            val decompileFuture = CompletableFuture<Unit>()
-            val queue = LinkedBlockingQueue<() -> Unit>()
+        val decompileFuture = CompletableFuture<Unit>()
+        val queue = LinkedBlockingQueue<() -> Unit>()
+        val canReadOnOwn = ApplicationManager.getApplication().isReadAccessAllowed
 
-            ApplicationManager.getApplication().executeOnPooledThread {
-                try {
-                    doDecompile { readTask ->
-                        val future = CompletableFuture<Unit>()
-                        queue.add {
-                            try {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            try {
+                doDecompile { readTask ->
+                    val future = CompletableFuture<Unit>()
+                    queue.add {
+                        try {
+                            if (canReadOnOwn) {
                                 readTask()
-                                future.complete(Unit)
-                            } catch (e: Throwable) {
-                                future.completeExceptionally(e)
+                            } else {
+                                ApplicationManager.getApplication().runReadAction(readTask)
                             }
-
+                            future.complete(Unit)
+                        } catch (e: Throwable) {
+                            future.completeExceptionally(e)
                         }
-                        future.join()
-                    }
 
-                    queue.add {
-                        decompileFuture.complete(Unit)
                     }
-                } catch (e: Throwable) {
-                    queue.add {
-                        decompileFuture.completeExceptionally(e)
-                    }
+                    future.join()
+                }
+
+                queue.add {
+                    decompileFuture.complete(Unit)
+                }
+            } catch (e: Throwable) {
+                queue.add {
+                    decompileFuture.completeExceptionally(e)
                 }
             }
-
-            while (!decompileFuture.isDone) {
-                queue.take()()
-            }
-            decompileFuture.join()
-        } else {
-            doDecompile {
-                ReadAction.run<Throwable>(it)
-            }
         }
+
+        while (!decompileFuture.isDone) {
+            queue.take()()
+        }
+        decompileFuture.join()
 
         // extract line mappings
         val mapping = myResultSaverMapping.get(resultSaver) as IntArray?
@@ -234,7 +232,7 @@ class VineflowerInvoker(classLoader: ClassLoader) {
         val baseDecompilerAddLibraryMethod = baseDecompilerClass.getMethod("addLibrary", iContextSourceClass)
     }
 
-    private class LanguageFeature(classLoader: ClassLoader) {
+    private inner class LanguageFeature(classLoader: ClassLoader) {
         private val dataInputFullStreamClass = classLoader.loadClass("org.jetbrains.java.decompiler.util.DataInputFullStream")
         private val dataInputFullStreamCtor = dataInputFullStreamClass.getConstructor(ByteArray::class.java)
 
@@ -245,15 +243,38 @@ class VineflowerInvoker(classLoader: ClassLoader) {
         private val getCurrentPluginContext = pluginContextClass.getMethod("getCurrentContext")
         private val pluginContextGetLanguageSpec = pluginContextClass.getMethod("getLanguageSpec", structClassClass)
 
-        private val languageSpecClass = classLoader.loadClass("org.jetbrains.java.decompiler.api.language.LanguageSpec")
+        private val languageSpecClass = classLoader.loadClass("org.jetbrains.java.decompiler.api.plugin.LanguageSpec")
         private val languageSpecName = languageSpecClass.getField("name")
 
+        private val clearContext = baseDecompilerClass.getMethod("clearContext")
+
+        private val getCurrentDecompContext = classLoader.loadClass("org.jetbrains.java.decompiler.main.DecompilerContext")
+            .getMethod("getCurrentContext")
+
         fun getLanguage(bytes: ByteArray): String {
-            val inputStream = dataInputFullStreamCtor.newInstance(bytes)
-            val structClass = structClassCreate.invoke(null, inputStream, true)
-            val pluginContext = getCurrentPluginContext.invoke(null)
-            val languageSpec = pluginContextGetLanguageSpec.invoke(pluginContext, structClass) ?: return "java"
-            return languageSpecName.get(languageSpec) as String
+            // ensure a decompilation context is available (otherwise the structclass constructor will fail)
+            val ff: Any?
+            if (getCurrentDecompContext.invoke(null) == null) {
+                val empty = emptyMap<Nothing, Nothing>()
+                val bytecodeProvider = myBytecodeProviderCtor.newInstance(empty)
+                val resultSaver = myResultSaverCtor.newInstance()
+
+                ff = baseDecompilerCtor.newInstance(bytecodeProvider, resultSaver, empty, myLogger)
+            } else {
+                ff = null
+            }
+
+            try {
+                val inputStream = dataInputFullStreamCtor.newInstance(bytes)
+                val structClass = structClassCreate.invoke(null, inputStream, true)
+                val pluginContext = getCurrentPluginContext.invoke(null)
+                val languageSpec = pluginContextGetLanguageSpec.invoke(pluginContext, structClass) ?: return "java"
+                return languageSpecName.get(languageSpec) as String
+            } finally {
+                if (ff != null) {
+                    clearContext.invoke(ff)
+                }
+            }
         }
     }
 }

--- a/src/main/kotlin/org/vineflower/ijplugin/VineflowerInvoker.kt
+++ b/src/main/kotlin/org/vineflower/ijplugin/VineflowerInvoker.kt
@@ -59,7 +59,7 @@ class VineflowerInvoker(classLoader: ClassLoader) {
         )
 
 
-    private val baseDecompilerClass = classLoader.loadClass("org.jetbrains.java.decompiler.main.Fernflower")
+    private val baseDecompilerClass = classLoader.loadClass("org.jetbrains.java.decompiler.main.decompiler.BaseDecompiler")
     private val baseDecompilerCtor = baseDecompilerClass.getConstructor(
         classLoader.loadClass("org.jetbrains.java.decompiler.main.extern.IBytecodeProvider"),
         classLoader.loadClass("org.jetbrains.java.decompiler.main.extern.IResultSaver"),
@@ -124,10 +124,11 @@ class VineflowerInvoker(classLoader: ClassLoader) {
             baseDecompilerDecompileContext.invoke(decompiler)
         }
 
-        // invoke the decompiler
-        // Read actions from within the decompiler may create a deadlock, as the decompiler itself creates threads.
-        // Solve this problem by running the decompiler on a separate thread, and executing read actions on either
-        // this thread if given read access, or with a read action if not.
+        // Invoke the decompiler
+        // Read actions from the same thread as the decompiler's main thread may create a deadlock.
+        // The reasoning is hard to figure out, but it seems to be related to threading done by the decompiler.
+        // As a fix, run the main decompiler thread separately and queue reads to be done on the main thread instead.
+        // TODO: Investigate the deadlock issue further
 
         val decompileFuture = CompletableFuture<Unit>()
         val queue = LinkedBlockingQueue<() -> Unit>()

--- a/src/main/kotlin/org/vineflower/ijplugin/VineflowerState.kt
+++ b/src/main/kotlin/org/vineflower/ijplugin/VineflowerState.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.util.JDOMUtil
-import com.intellij.util.io.readText
 import com.intellij.util.text.SemVer
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.Tag
@@ -25,6 +24,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.stream.Collectors
 import kotlin.io.path.exists
+import kotlin.io.path.readText
 
 @State(
     name = "net.earthcomputer.quiltflowerintellij.QuiltflowerState",

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,6 +6,7 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.java</depends>
+    <depends>org.jetbrains.kotlin</depends>
 
     <applicationListeners>
         <listener class="org.vineflower.ijplugin.VineflowerPreloader" topic="com.intellij.ide.AppLifecycleListener"/>
@@ -20,5 +21,7 @@
                 displayName="Vineflower"/>
         <applicationService serviceImplementation="org.vineflower.ijplugin.VineflowerState"/>
         <psi.classFileDecompiler implementation="org.vineflower.ijplugin.VineflowerDecompilerLight" order="first"/>
+<!--        <psi.classFileDecompiler implementation="org.vineflower.ijplugin.VineflowerDecompilerJava" order="first"/>-->
+        <psi.classFileDecompiler implementation="org.vineflower.ijplugin.VineflowerDecompilerKotlin" order="first"/>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -21,7 +21,6 @@
                 displayName="Vineflower"/>
         <applicationService serviceImplementation="org.vineflower.ijplugin.VineflowerState"/>
         <psi.classFileDecompiler implementation="org.vineflower.ijplugin.VineflowerDecompilerLight" order="first"/>
-<!--        <psi.classFileDecompiler implementation="org.vineflower.ijplugin.VineflowerDecompilerJava" order="first"/>-->
         <psi.classFileDecompiler implementation="org.vineflower.ijplugin.VineflowerDecompilerKotlin" order="first"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
After a handful of messing around, I've succeeded in some key goals, and I think it's enough to improve the plugin enough

- Update a bunch of things
  - Gradle 7.6 -> 8.9
  - Java 11 -> 17
  - Kotlin 1.8.0 -> 1.9.22
  - IntelliJ 2023.1 -> 2024.1 (Kotlin plugin reasons)
  - Gradle IntelliJ Plugin 1.13.2 -> IntelliJ Platform Plugin 2.0.1
- Create a Full decompiler for Kotlin
  - The decompiler is a bit buggy as of now and has unexpected psi issues
- Update language checking to match that of latest Vineflower versions
- Presumably fix #21
- Change version to Semver equivalent (remains at 1.1.0)
